### PR TITLE
Update README.md

### DIFF
--- a/proposals/resource-parameters/README.md
+++ b/proposals/resource-parameters/README.md
@@ -16,3 +16,5 @@ Typically, (REST) resources are used with query parameters such as /resource?par
 	"inputType":{"properties":{"includTimestamp", type:"boolean"}}
 	"href": "temp?inc_ts={includeTimestamp}"
 }
+
+Alternatively, we could adopt json hyperschema such links are part of the type itself.

--- a/proposals/resource-parameters/README.md
+++ b/proposals/resource-parameters/README.md
@@ -9,3 +9,10 @@ Typically, (REST) resources are used with query parameters such as /resource?par
 
 #First Ideas
 1)  define query parameters in the same way as the inputValue and outputValues
+2) Use URI template and pre-processing similar to JSON Hyperschema proposal. Example:
+
+{
+	"name": "temperature",
+	"inputType":{"properties":{"includTimestamp", type:"boolean"}}
+	"href": "temp?inc_ts={includeTimestamp}"
+}


### PR DESCRIPTION
This is a very relevant topic, thanks for bringing it up. Query parameters are often used to determine the response content - from the simplest case where the measurement system (SI, Metric..) is stated or where the information to be included in the response is stated. URI templates look promising fit for this, but I am not sure how..
